### PR TITLE
Enabling raw flag.

### DIFF
--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -31,6 +31,7 @@ var (
 	azureOpenAIEndpoint  = flag.String("azure-openai-endpoint", env.GetOr("AZURE_OPENAI_ENDPOINT", env.String, ""), "The endpoint for Azure OpenAI service. If provided, Azure OpenAI service will be used instead of OpenAI service.")
 	requireConfirmation  = flag.Bool("require-confirmation", env.GetOr("REQUIRE_CONFIRMATION", strconv.ParseBool, true), "Whether to require confirmation before executing the command. Defaults to true.")
 	temperature          = flag.Float64("temperature", env.GetOr("TEMPERATURE", env.WithBitSize(strconv.ParseFloat, 64), 0.0), "The temperature to use for the model. Range is between 0 and 1. Set closer to 0 if your want output to be more deterministic but less creative. Defaults to 0.0.")
+	raw                  = flag.String("raw", "", "This output of the generated YAML.")
 )
 
 func InitAndExecute() {
@@ -89,16 +90,22 @@ func run(args []string) error {
 			return err
 		}
 
-		text := fmt.Sprintf("✨ Attempting to apply the following manifest:\n%s", completion)
-		fmt.Println(text)
-
-		action, err = userActionPrompt()
-		if err != nil {
-			return err
-		}
-
-		if action == dontApply {
+		if *raw == "raw" {
+			fmt.Println(completion)
 			return nil
+		} else {
+
+			text := fmt.Sprintf("✨ Attempting to apply the following manifest:\n%s", completion)
+			fmt.Println(text)
+
+			action, err = userActionPrompt()
+			if err != nil {
+				return err
+			}
+
+			if action == dontApply {
+				return nil
+			}
 		}
 	}
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -31,7 +31,7 @@ var (
 	azureOpenAIEndpoint  = flag.String("azure-openai-endpoint", env.GetOr("AZURE_OPENAI_ENDPOINT", env.String, ""), "The endpoint for Azure OpenAI service. If provided, Azure OpenAI service will be used instead of OpenAI service.")
 	requireConfirmation  = flag.Bool("require-confirmation", env.GetOr("REQUIRE_CONFIRMATION", strconv.ParseBool, true), "Whether to require confirmation before executing the command. Defaults to true.")
 	temperature          = flag.Float64("temperature", env.GetOr("TEMPERATURE", env.WithBitSize(strconv.ParseFloat, 64), 0.0), "The temperature to use for the model. Range is between 0 and 1. Set closer to 0 if your want output to be more deterministic but less creative. Defaults to 0.0.")
-	raw                  = flag.String("raw", "", "This output of the generated YAML.")
+	raw                  = flag.Bool("raw", false, "This generate raw output of the YAML.")
 )
 
 func InitAndExecute() {
@@ -90,7 +90,7 @@ func run(args []string) error {
 			return err
 		}
 
-		if *raw == "raw" {
+		if *raw {
 			fmt.Println(completion)
 			return nil
 		} else {

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -93,19 +93,17 @@ func run(args []string) error {
 		if *raw {
 			fmt.Println(completion)
 			return nil
-		} else {
+		}
+		text := fmt.Sprintf("✨ Attempting to apply the following manifest:\n%s", completion)
+		fmt.Println(text)
 
-			text := fmt.Sprintf("✨ Attempting to apply the following manifest:\n%s", completion)
-			fmt.Println(text)
+		action, err = userActionPrompt()
+		if err != nil {
+			return err
+		}
 
-			action, err = userActionPrompt()
-			if err != nil {
-				return err
-			}
-
-			if action == dontApply {
-				return nil
-			}
+		if action == dontApply {
+			return nil
 		}
 	}
 

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -31,7 +31,7 @@ var (
 	azureOpenAIEndpoint  = flag.String("azure-openai-endpoint", env.GetOr("AZURE_OPENAI_ENDPOINT", env.String, ""), "The endpoint for Azure OpenAI service. If provided, Azure OpenAI service will be used instead of OpenAI service.")
 	requireConfirmation  = flag.Bool("require-confirmation", env.GetOr("REQUIRE_CONFIRMATION", strconv.ParseBool, true), "Whether to require confirmation before executing the command. Defaults to true.")
 	temperature          = flag.Float64("temperature", env.GetOr("TEMPERATURE", env.WithBitSize(strconv.ParseFloat, 64), 0.0), "The temperature to use for the model. Range is between 0 and 1. Set closer to 0 if your want output to be more deterministic but less creative. Defaults to 0.0.")
-	raw                  = flag.Bool("raw", false, "This generate raw output of the YAML.")
+	raw                  = flag.Bool("raw", false, "Prints the raw YAML output immediately. Defaults to false.")
 )
 
 func InitAndExecute() {


### PR DESCRIPTION
This PR enables the `--raw` flag with an intent to produce the yaml only raw output without the prompts or extra text.

### Usage

* `kubectl-ai "create nginx deployment" --raw` 

### Output

<img width="845" alt="Screenshot 2023-04-18 at 1 36 48 PM" src="https://user-images.githubusercontent.com/6233295/232647081-2c6ff3f2-4f17-4ff8-84b7-d2efa7b2a781.png">


Thank heaps for taking time and looking into this PR. ❤️☕️🙏 @sozercan , fyi - @gambtho 
