### PR TITLE
Add Windows build into release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
     goos:
     - linux
     - darwin
+    - windows
     goarch:
     - amd64
     - arm64


### PR DESCRIPTION
Having a Windows build would be really useful for the VS Code integration (since a LOT of VS Code users are on Windows).

Tested on [my own fork](https://github.com/peterbom/kubectl-ai/releases) (although I removed the `brews` and `krews` sections there, which I don't _think_ should make a difference) and the resulting `.zip` file appears to be correct.

cc: @Tatsinnit, @sozercan 